### PR TITLE
Refactored and new API.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,10 @@
 .jsbeautifyrc
+.tools
 .vscode
 __tests__
 coverage
 gulpfile.js
+jsconfig.json
 node_modules
 publish.exp
 src

--- a/README.md
+++ b/README.md
@@ -35,13 +35,17 @@ console.log(JSON.stringify(personality, null, 4)); // See: Result 1
 const inner = wadjet.detail(result.inner);
 console.log(typeof inner); // object
 console.log(JSON.stringify(inner, null, 4)); // See: Result 2
+
+const team = wadjet.bizTeam(inner.business, result.inner, inner.position);
+console.log(typeof team); // object
+console.log(JSON.stringify(team, null, 4)); // See: Result 3
 ```
 
 ### Result
 
 #### 1
 
-```JSON
+```JavaScript
 {
     "cycle": 4,
     "inner": "E919",
@@ -54,14 +58,14 @@ console.log(JSON.stringify(inner, null, 4)); // See: Result 2
 
 #### 2
 
-```JSON
+```JavaScript
 {
     "communication": "Fix",
     "management": "Hope",
     "response": "Action",
     "position": "Quick",
     "motivation": "Competition",
-    "nature": "E919",
+    "nature": "E919", // <- DEPRECATED: described later
     "romance": {
         "A000": 2,
         "A024": 0,
@@ -93,6 +97,16 @@ console.log(JSON.stringify(inner, null, 4)); // See: Result 2
 }
 ```
 
+#### 3
+
+```JavaScript
+{
+    "Direct": "H789",
+    "Brain": "H108",
+    "Adjust": "E125"
+}
+```
+
 ## Dependencies
 
 * nodejs >= 4.8.3
@@ -114,26 +128,48 @@ If you want the CommonJS style notation:
 const wadjet = require('wadjet').default;
 ```
 
-### `wadjet.affinity`
+### `wadjet.bizTeam`
 
-Evaluation function used for sorting in affinity order.
+Create personality types list of best affinitic for team.
 
 ```JavaScript
-wadjet.detail(a: String, b: String) -> Number
+wadjet.bizTeam(business: Object.<string, number>, personality: string, position?: string) -> Object.<string, string>
 ```
 
-* `a`: Personality type.
-* `b`: Personality type.
+* `business`: Good business formation levels.
+* `personality`: Personality type.
+* `position`: Position type. Optional.
+
+### `wadjet.comparator`
+
+Create evaluation function used for sorting in affinity order.
+
+```JavaScript
+wadjet.comparator(type: String) -> (a: String, b: String) -> -1 | 0 | 1
+```
+
+* `type`: Personality type.
 
 ### `wadjet.detail`
 
-Get the details corresponding to the specified nature.
+Get the details corresponding to the specified personality.
 
 ```JavaScript
-wadjet.detail(key: String) -> Object
+wadjet.detail(key: String) -> {
+    communication: String,
+    management: String,
+    motivation: String,
+    nature: String, /* DEPRECATED */
+    response: String,
+    position: String,
+    romance: Object.<string, number>,
+    business: Object.<string, number>
+}
 ```
 
-* `key`: Nature type.
+* `key`: Personality type.
+
+__The "nature" property in return value__ has been DEPRECATED since version 3.3.0. It will __no longer be version 4.0.0 or later.__  
 
 ### `wadjet.personality`
 
@@ -160,10 +196,24 @@ wadjet.types -> ReadonlyArray.<String>
 
 * `birth`: Birthday. It can be set _from 1873-02-01 to 2050-12-31_.
 
+### `wadjet.affinity` [DEPRECATED]
+
+__This function is DEPRECATED since version 3.3.0. And will no longer since version 4.0.0.__  
+Should use `personality` function.
+
+Evaluation function used for sorting in affinity order.
+
+```JavaScript
+wadjet.detail(a: String, b: String) -> Number
+```
+
+* `a`: Personality type.
+* `b`: Personality type.
+
 ### `wadjet.calc` [DEPRECATED]
 
 __This function is DEPRECATED since version 3.2.0. And will no longer since version 4.0.0.__  
-Should use `personality` function.
+Should use `wadjet.personality` function.
 
 Get personality from birthday.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm version](https://badge.fury.io/js/wadjet.svg)](https://badge.fury.io/js/wadjet)
 [![npm download](https://img.shields.io/npm/dm/wadjet.svg?style=flat-square)](https://npmjs.org/package/wadjet)
 
-# 👁️‍🗨️ Wadjet
+# ![👁️‍🗨️ Wadjet](https://raw.githubusercontent.com/danmaq/wadjet/images/wadjet.svg?sanitize=true)
 
 🔮🎂 The __your birth date__ is based on statistical psychology and will __expose your personality__.
 This package as a module does its calculations.

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "esnext",
+        "module": "commonjs",
+        "allowSyntheticDefaultImports": true,
+        "experimentalDecorators": true,
+        "baseUrl": "."
+    },
+    "exclude": [
+        "node_modules"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wadjet",
-    "version": "3.2.0",
+    "version": "3.3.0",
     "description": "The your birth date is based on statistical psychology and will expose your personality. This package as a mocule does its calculations.",
     "author": {
         "name": "Shuhei Nomura (danmaq)",

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,68 @@
 'use strict';
 
 import _natures from './enum/natures';
-import _affinity from './util/affinity';
+import { affinity, createComparator } from './util/affinity';
+import _bizTeam from './util/bizTeam';
 import _calculator_deprecated from './util/calculator_deprecated';
 import _personality from './util/personality';
 import _naturesDesc from './master/naturesDesc';
+
+/**
+ * Evaluation function used for sorting in affinity order.
+ * @deprecated This function is DEPRECATED since version 3.3.0. And will no longer since version 4.0.0.
+ *
+ * Use `comparator` function.
+ * @param {string} a Personality type.
+ * @param {string} b Personality type.
+ * @returns {number} Comparison result.
+ */
+const _affinity = affinity;
+
+/**
+ * Create personality types list of best affinitic for team.
+ * @param {Object.<string, number>} business Good business formation levels.
+ * @param {string} personality Personality type.
+ * @param {string} [position] Position type.
+ * @returns {Object.<string, string>} Personality types list.
+ */
+const bizTeam = _bizTeam;
+
+/**
+ * @callback Comparator
+ * @param {string} a Personality type.
+ * @param {string} b Personality type.
+ * @returns {-1|0|1} Comparison result.
+ */
+
+/**
+ * Create evaluation function used for sorting in affinity order.
+ * @param {string} type Personality type.
+ * @returns {Comparator} Comparator function.
+ */
+const comparator = createComparator;
+
+/**
+ * Get the details corresponding to the specified nature.
+ * @param {string} key Nature key.
+ * @returns {{communication: string, management: string, response: string, position: string, motivation: string, nature: string, romance: Object.<string, number>, business: Object.<string, number>}} Detail.
+ */
+const detail = _naturesDesc;
+
+/**
+ * Get personality from birthday.
+ * @param {Date|string} birth Birthday.
+ * 
+ * It can be set from 1873-02-01 to 2050-12-31.
+ * @returns {{cycle: number, inner: string, lifeBase: string, outer: string, potential: string, workstyle: string}} Personality.
+ * @throws {Error} When birthday specified invalid value.
+ */
+const personality = _personality;
+
+/**
+ * Natures values list.
+ * @type {ReadonlyArray.<string>}
+ */
+const types = _natures;
 
 /**
  * Get personality from birthday.
@@ -18,41 +76,12 @@ import _naturesDesc from './master/naturesDesc';
  */
 const calc = _calculator_deprecated;
 
-/**
- * Get personality from birthday.
- * @param {Date|string} birth Birthday.
- * 
- * It can be set from 1873-02-01 to 2050-12-31.
- * @returns {{cycle: number, inner: string, lifeBase: string, outer: string, potential: string, workstyle: string}} Personality.
- * @throws {Error} When birthday specified invalid value.
- */
-const personality = _personality;
-
-/**
- * Get the details corresponding to the specified nature.
- * @param {string} key Nature key.
- * @returns {{communication: string, management: string, response: string, position: string, motivation: string, nature: string, romance: Object.<string, number>, business: Object.<string, number>}} Detail.
- */
-const detail = _naturesDesc;
-
-/**
- * Natures values list.
- * @type {ReadonlyArray.<string>}
- */
-const types = _natures;
-
-/**
- * Evaluation function used for sorting in affinity order.
- * @param {string} a Personality type.
- * @param {string} b Personality type.
- * @returns {number} Evaluation rate.
- */
-const affinity = _affinity;
-
 export default Object.freeze({
-    affinity,
-    calc,
-    personality,
+    affinity: _affinity,
+    bizTeam,
+    comparator,
     detail,
-    types
+    personality,
+    types,
+    calc,
 });

--- a/src/util/affinity.js
+++ b/src/util/affinity.js
@@ -2,18 +2,86 @@
 
 /**
  * Evaluation function used for sorting in affinity order.
+ * @deprecated This function is DEPRECATED since version 3.3.0. And will no longer since version 4.0.0.
+ * 
+ * Use `comparator` function.
  * @param {string} a Personality type.
  * @param {string} b Personality type.
- * @returns {number} Evaluation rate.
+ * @returns {number} Comparison result.
  */
-const affinity =
+export const affinity =
+    (a, b) => {
+        console.warn(
+            'This function is DEPRECATED since version 3.3.0. And will no longer since version 4.0.0. Use `comparator` function.'
+        );
+        const _a = a.charAt().toUpperCase();
+        const _b = b.charAt().toUpperCase();
+        const result =
+            _a === _b || /[^EAH]/.test(_b) ? 0 :
+            _a === 'H' ? (_b === 'E' ? 1 : -1) :
+            _a === 'E' ? (_b === 'A' ? 1 : -1) :
+            _a === 'A' ? (_b === 'H' ? 1 : -1) :
+            0;
+        return result;
+    };
+
+/**
+ * Evaluation function used for sorting in affinity order.
+ * @param {'A'|'E'|'H'} a Personality type.
+ * @param {'A'|'E'|'H'} b Personality type.
+ * @return {-1|1} Comparison result.
+ */
+const cmpA =
     (a, b) =>
-    ((_a, _b) =>
-        _a === _b || /[^EAH]/.test(_b) ? 0 :
-        _a === 'H' ? (_b === 'E' ? 1 : -1) :
-        _a === 'E' ? (_b === 'A' ? 1 : -1) :
-        _a === 'A' ? (_b === 'H' ? 1 : -1) :
-        0
-    )(a.charAt().toUpperCase(), b.charAt().toUpperCase());
+    a === 'E' && b === 'A' ||
+    a === 'A' && b === 'H' ||
+    a === 'E' && b === 'H' ?
+    1 : -1;
+/**
+ * Evaluation function used for sorting in affinity order.
+ * @param {'A'|'E'|'H'} a Personality type.
+ * @param {'A'|'E'|'H'} b Personality type.
+ * @return {-1|1} Comparison result.
+ */
+const cmpE =
+    (a, b) =>
+    a === 'H' && b === 'E' ||
+    a === 'E' && b === 'A' ||
+    a === 'H' && b === 'A' ?
+    1 : -1;
+/**
+ * Evaluation function used for sorting in affinity order.
+ * @param {'A'|'E'|'H'} a Personality type.
+ * @param {'A'|'E'|'H'} b Personality type.
+ * @return {-1|1} Comparison result.
+ */
+const cmpH =
+    (a, b) =>
+    a === 'A' && b === 'H' ||
+    a === 'H' && b === 'E' ||
+    a === 'A' && b === 'E' ?
+    1 : -1;
+
+const cmp = { A: cmpA, E: cmpE, H: cmpH };
+
+/**
+ * Create evaluation function used for sorting in affinity order.
+ * @param {string} type Personality type.
+ */
+export const createComparator =
+    type =>
+    /**
+     * @param {string} a Personality type.
+     * @param {string} b Personality type.
+     * @returns {-1|0|1}
+     */
+    (a, b) =>
+    ((x, y, t, p) =>
+        x === y || p.test(x) || p.test(y) || p.test(t) ? 0 : cmp[t](x, y)
+    )(
+        a.charAt().toUpperCase(),
+        b.charAt().toUpperCase(),
+        type.charAt().toUpperCase(),
+        /[^EAH]/) >> 0;
 
 export default affinity;

--- a/src/util/bizTeam.js
+++ b/src/util/bizTeam.js
@@ -1,0 +1,36 @@
+'use strict';
+
+import naturesDesc from '../master/naturesDesc';
+
+import { createComparator } from './affinity';
+
+/**
+ * Create personality types list of best affinitic for team.
+ * @param {Object.<string, number>} business Good business formation levels.
+ * @param {string} personality Personality type.
+ * @param {string} [position] Position type.
+ * @returns {Object.<string, string>} Personality types list.
+ */
+const bizTeam =
+    (business, personality, position) => {
+        const map =
+            Object
+            .entries(business)
+            .map(
+                ([type, pri]) =>
+                ({ type, pri, pos: naturesDesc(type).position }));
+        const comparator = createComparator(personality);
+        // NOTE: sort() function performs a destructive change,
+        // and return value depends on environment.
+        map.sort(
+            ({ pri: pa, type: ta }, { pri: pb, type: tb }) =>
+            pa !== pb ? -(pa - pb) : comparator(ta, tb));
+        const result =
+            map.reduce(
+                (p, { pos, type }) =>
+                pos === position || pos in p ? p :
+                ({ ...p, [pos]: type }), {});
+        return result;
+    };
+
+export default bizTeam;

--- a/src/util/natureMap.js
+++ b/src/util/natureMap.js
@@ -5,6 +5,7 @@ import natures from '../enum/natures';
 /**
  * Generate a nature map by specified table.
  * @param {number[][]} table Values table.
+ * @returns {Object.<string, Object.<string, number>>} Personality map.
  */
 const natureMap =
     table =>

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,7 @@ test('is Object', () => expect(wadjet).toBeInstanceOf(Object));
 test('is Included APIs', () => {
     expect(wadjet.affinity).toBeInstanceOf(Function);
     expect(wadjet.calc).toBeInstanceOf(Function);
+    expect(wadjet.comparator).toBeInstanceOf(Function);
     expect(wadjet.detail).toBeInstanceOf(Function);
     expect(wadjet.personality).toBeInstanceOf(Function);
     expect(wadjet.types).toBeInstanceOf(Array);

--- a/test/util/affinity.js
+++ b/test/util/affinity.js
@@ -1,31 +1,31 @@
 'use strict';
 
-import affinity from '../../dist/util/affinity';
+import * as affinity from '../../dist/util/affinity';
 
 test(
-    'Whether is `affinity` function object.',
-    () => expect(affinity).toBeInstanceOf(Function));
+    'Whether is `affinity.affinity` function object.',
+    () => expect(affinity.affinity).toBeInstanceOf(Function));
 test(
     'When comparing with the same value, returned 0',
     () => {
-        expect(affinity('H', 'H')).toBe(0);
-        expect(affinity('E', 'E')).toBe(0);
-        expect(affinity('A', 'A')).toBe(0);
+        expect(affinity.affinity('H', 'H')).toBe(0);
+        expect(affinity.affinity('E', 'E')).toBe(0);
+        expect(affinity.affinity('A', 'A')).toBe(0);
     });
 test(
     'When comparing with the different value, returned 1 or -1',
     () => {
-        expect(affinity('H', 'E')).toBe(1);
-        expect(affinity('E', 'A')).toBe(1);
-        expect(affinity('A', 'H')).toBe(1);
-        expect(affinity('H', 'A')).toBe(-1);
-        expect(affinity('A', 'E')).toBe(-1);
-        expect(affinity('E', 'H')).toBe(-1);
+        expect(affinity.affinity('H', 'E')).toBe(1);
+        expect(affinity.affinity('E', 'A')).toBe(1);
+        expect(affinity.affinity('A', 'H')).toBe(1);
+        expect(affinity.affinity('H', 'A')).toBe(-1);
+        expect(affinity.affinity('A', 'E')).toBe(-1);
+        expect(affinity.affinity('E', 'H')).toBe(-1);
     });
 test(
     'When specified invalid value, returned 0',
     () => {
-        expect(affinity('Z', 'H')).toBe(0);
-        expect(affinity('E', 'Z')).toBe(0);
-        expect(affinity('Z', 'Z')).toBe(0);
+        expect(affinity.affinity('Z', 'H')).toBe(0);
+        expect(affinity.affinity('E', 'Z')).toBe(0);
+        expect(affinity.affinity('Z', 'Z')).toBe(0);
     });

--- a/test/util/bizTeam.js
+++ b/test/util/bizTeam.js
@@ -1,0 +1,36 @@
+'use strict';
+
+import bizTeam from '../../dist/util/bizTeam';
+import natureBiz from '../../dist/master/natureBiz';
+
+test(
+    'Whether is `bizTeam` function object.',
+    () => expect(bizTeam).toBeInstanceOf(Function));
+
+test(
+    'Whether possible to obtain correct value corresponding to correct input: Pattern A',
+    () => {
+        for (const [key, value] of Object.entries(natureBiz)) {
+            const result = bizTeam(value, key);
+            expect(result).toBeInstanceOf(Object);
+            expect(Object.keys(result).length).toEqual(4);
+            for (const [k, v] of Object.entries(result)) {
+                expect(k).toMatch(/^[A-Z]\w+/);
+                expect(v).toMatch(/^[AEH]\d{3}/);
+            }
+        }
+    });
+
+test(
+    'Whether possible to obtain correct value corresponding to correct input: Pattern B',
+    () => {
+        for (const [key, value] of Object.entries(natureBiz)) {
+            const result = bizTeam(value, key, 'Direct');
+            expect(result).toBeInstanceOf(Object);
+            expect(Object.keys(result).length).toEqual(3);
+            for (const [k, v] of Object.entries(result)) {
+                expect(k).toMatch(/^[A-Z]\w+/);
+                expect(v).toMatch(/^[AEH]\d{3}/);
+            }
+        }
+    });


### PR DESCRIPTION
* Deprecated API.
    * `wadjet.affinity()`: Although it can still be used, it will be __unusable from version 4.0.0.__
    * `wadjet.detail(...).nature`: Although it can still be used, it will be __unusable from version 4.0.0.__
* Added API.
    * `wadjet.bizTeam()`: Create personality types list of best affinitic for team.
    * `wadjet.comparator()`: Create evaluation function used for sorting in affinity order.
* Added documentation.